### PR TITLE
Yarn/npm Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-bower_components/*/
 .sass-cache/
 .idea/
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ A stack-agnostic SASS library providing a framework-agnostic, [Neat](http://neat
 
 ### Consumption
 
-Install with Bower (from an appropriate repository)
+Add and install with Yarn:
 
 ```sh
-$ bower install employer-style-grid
+$ yarn add employer-style-grid
 ```
 
 Now, import `sass/grid` after [Neat](http://neat.bourbon.io/) Helpers, and after a framework like [Bourbon](http://bourbon.io/) in your main `application.scss`. Then, import Neat. For example:
 
 ```scss
-@import 'bower_components/bourbon/app/assets/stylesheets/bourbon';
-@import 'bower_components/neat/app/assets/stylesheets/neat-helpers';
-@import 'bower_components/employer-style-grid/sass/grid';
-@import 'bower_components/neat/app/assets/stylesheets/neat';
+@import 'bourbon/app/assets/stylesheets/bourbon';
+@import 'bourbon-neat/app/assets/stylesheets/neat-helpers';
+@import 'employer-style-grid/sass/grid';
+@import 'bourbon-neat/app/assets/stylesheets/neat';
 
 @import 'your-app';
 ```
@@ -25,7 +25,21 @@ You can now use [Neat mixins](http://thoughtbot.github.io/neat-docs/latest/) and
 
 ### What's included
 
-At the moment, only uncompiled SASS source files are available for consumption. That means your application will need to perform the precompilation, whether it be through Gulp, Grunt, Rails asset pipeline, etc. Do note that `employer-style-grid` simply wraps around, and depends upon [Neat](http://neat.bourbon.io/) to actually power its grid system.
+At the moment, only uncompiled SASS source files are available for consumption. That means your application will need to perform the precompilation, whether it be through Webpack, Gulp, Grunt, Rails asset pipeline, etc. Do note that `employer-style-grid` simply wraps around and depends upon [Neat](http://neat.bourbon.io/) to actually power its grid system.
+
+### Contributing
+
+#### Updating the Version
+
+After your PR is merged, update the [semantic version number appropriately](http://semver.org/), add a [release](https://github.com/cb-talent-development/employer-style-grid/releases) and `publish` via Yarn or npm.
+
+Then update the `package.json` file in your project with the new version:
+
+```json
+  "dependencies": {
+    "employer-style-grid": "=1.0.0"
+  }
+```
 
 ### Future
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "employer-style-grid",
   "version": "1.0.0",
-  "authors": [
-    "Content Enablement <ContentEnablementProductTeam@careerbuilder.com>"
-  ],
+  "author": "EmployerSiteContentProducts@cb.com",
+  "license": "Apache-2.0",
   "description": "A stack-agnostic SASS library providing a framework-agnostic, Neat-based grid system intended for the Employer experience",
+  "repository": "github:cb-talent-development/employer-style-grid",
   "keywords": [
     "cb",
     "careerbuilder",
@@ -16,18 +16,11 @@
     "sass",
     "css"
   ],
-  "main": [
-    "sass/_grid.scss",
-    "sass/_grid-settings.scss"
+  "files": [
+    "sass"
   ],
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ],
+  "main": "sass/_grid.scss",
   "dependencies": {
-    "neat": "~1.7.2"
+    "bourbon-neat": "^2.0.0"
   }
 }


### PR DESCRIPTION
This removes Bower support and migrates `employer-style-grid` to Yarn/npm